### PR TITLE
Improved build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #/bin/sh
-rm -f unicensd xml2struct
+rm -f unicensd
 mkdir -p out
 cd out
 cmake ..


### PR DESCRIPTION
If the user imports a non working XML to C code (using xml2struct tool), then xml2struct will be deleted and it's getting hard to repair the source code of unicensd again.