### PR TITLE
cmake: use gnu99 as default for c sources

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 FILE(GLOB MyCSources *.c)
 add_executable (unicensd ${MyCSources})
+add_definitions(" -std=gnu99")
 target_include_directories (unicensd 
 	PUBLIC 
 	${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
This prevents the compiler warning:
ISO C90 forbids specifying subobject to initialize [-Wpedantic]
for the src/default_config.c